### PR TITLE
gitattributes: Allow diffing *.SHA256SUMS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-*.SHA256SUMS -text -diff
+*.SHA256SUMS -text
 *.SHA256SUMS.asc -text -diff


### PR DESCRIPTION
`*.SHA256SUMS` files are human-readable, and therefore diffs will be meaningful