### PR TITLE
 ci: Check presence of builder keys 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ lint_task:
   use_compute_credits: true
   only_if: $CIRRUS_BASE_BRANCH == 'main'
   stateful: false  # https://cirrus-ci.org/guide/writing-tasks/#stateful-tasks
-  setup_script: apt-get update && apt-get install -y git
+  setup_script: apt-get update && apt-get install -y git libgpgme-dev
   merge_base_script:
     - git fetch $CIRRUS_REPO_CLONE_URL "pull/${CIRRUS_PR}/merge"
     - git checkout FETCH_HEAD  # Derive full diff based on merge commit, see lint_script

--- a/contrib/touched-files-check/Cargo.lock
+++ b/contrib/touched-files-check/Cargo.lock
@@ -12,10 +12,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "conv"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+dependencies = [
+ "custom_derive",
+]
+
+[[package]]
+name = "cstr-argument"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
+dependencies = [
+ "cfg-if",
+ "memchr",
+]
+
+[[package]]
+name = "custom_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
+
+[[package]]
+name = "gpg-error"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7073b9ac823434ae73608715086e944d694a7ce2677371b8c5253300d1f767f1"
+dependencies = [
+ "libgpg-error-sys",
+]
+
+[[package]]
+name = "gpgme"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64070c0f3dc514656d6d21b5c0b8a088db2f74d889410378340039088d6ae32b"
+dependencies = [
+ "bitflags",
+ "conv",
+ "cstr-argument",
+ "gpg-error",
+ "gpgme-sys",
+ "libc",
+ "once_cell",
+ "smallvec",
+ "static_assertions",
+]
+
+[[package]]
+name = "gpgme-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9555986d7ef4c6c5bb57469f74df57bcc1a7c686a6de7c9be71e3377a095756"
+dependencies = [
+ "libc",
+ "libgpg-error-sys",
+ "winreg 0.9.0",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.138"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+
+[[package]]
+name = "libgpg-error-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1aedf0efc5d25fdd08eb52b0759c71d02ac77fd1879b96e95211239528897"
+dependencies = [
+ "libc",
+ "winreg 0.7.0",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "once_cell"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "regex"
@@ -35,8 +131,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "touched-files-check"
 version = "0.1.0"
 dependencies = [
+ "gpgme",
  "regex",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16cdb3898397cf7f624c294948669beafaeebc5577d5ec53d0afb76633593597"
+dependencies = [
+ "winapi",
 ]

--- a/contrib/touched-files-check/Cargo.toml
+++ b/contrib/touched-files-check/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+gpgme = "0.10"
 regex = "1"

--- a/contrib/touched-files-check/src/main.rs
+++ b/contrib/touched-files-check/src/main.rs
@@ -1,8 +1,10 @@
-fn check(touched_files: &str) -> Result<(), String> {
+use std::collections::{HashMap, HashSet};
+
+fn check(touched_files: &str) -> Result<(Vec<&str>, HashSet<&str>), String> {
     let attestation_regex = regex::Regex::new("^([^/]+/[^/]+/[^/]+.SHA256SUMS)(|.asc)$").unwrap();
-    let mut attestations = std::collections::HashMap::new();
+    let mut attestations = HashMap::new();
     let builder_key_regex = regex::Regex::new("^(builder-keys/[^/]+.gpg)$").unwrap();
-    let mut builder_keys = Vec::new();
+    let mut builder_keys = HashSet::new();
     for line in touched_files.lines() {
         let (status, file) = {
             let mut l = line.split_whitespace();
@@ -25,7 +27,7 @@ fn check(touched_files: &str) -> Result<(), String> {
                 ));
             }
         } else if let Some(path) = builder_key_regex.captures(file) {
-            builder_keys.push(path.get(1).unwrap().as_str());
+            assert!(builder_keys.insert(path.get(1).unwrap().as_str()));
             if status != "A" && status != "M" {
                 return Err(format!(
                     "File status for builder key is not 'A' (for add) or 'M' (for modified): '{status}' '{file}'"
@@ -35,14 +37,14 @@ fn check(touched_files: &str) -> Result<(), String> {
             return Err(format!("Added unknown file '{file}'"));
         }
     }
-    for (path, asc) in attestations {
+    for (path, asc) in &attestations {
         if asc.len() != 2 {
             return Err(format!(
                 "Missing SHA256SUMS.asc or SHA256SUMS file in {path}"
             ));
         }
     }
-    Ok(())
+    Ok((attestations.into_keys().collect(), builder_keys))
 }
 
 fn main() {
@@ -60,7 +62,7 @@ fn main() {
 
 #[test]
 fn test_check() {
-    assert_eq!(check("M README.md"), Ok(()));
+    assert_eq!(check("M README.md"), Ok((vec![], HashSet::new())));
     assert_eq!(
         check("B 22.0/user/all.SHA256SUMS").unwrap_err(),
         "File status for attestation is not 'A' (for add): 'B' '22.0/user/all.SHA256SUMS'"
@@ -75,11 +77,14 @@ fn test_check() {
     );
     assert_eq!(
         check("A 22.0/user/all.SHA256SUMS\nA 22.0/user/all.SHA256SUMS.asc"),
-        Ok(())
+        Ok((vec!["22.0/user/all.SHA256SUMS"], HashSet::new()))
     );
     assert_eq!(
         check("B builder-keys/user.gpg").unwrap_err(),
         "File status for builder key is not 'A' (for add) or 'M' (for modified): 'B' 'builder-keys/user.gpg'",
     );
-    assert_eq!(check("M builder-keys/user.gpg"), Ok(()));
+    assert_eq!(
+        check("M builder-keys/user.gpg"),
+        Ok((vec![], HashSet::from(["builder-keys/user.gpg"])))
+    );
 }


### PR DESCRIPTION
Not having the builder keys in this repo has many issues, for example:

* People accidentally sign with the wrong key (https://github.com/bitcoin/bitcoin/pull/26598#discussion_r1034815576)
* People forget to upload the key at all (https://github.com/bitcoin/bitcoin/pull/26598#issuecomment-1330674639)
* It puts a burden on another project to maintain a map of fingerprints to names (https://github.com/bitcoin/bitcoin/pull/26598#issuecomment-1336522258)
* The external list of fingerprints has questionable benefits (https://github.com/bitcoin/bitcoin/pull/26598#issuecomment-1332001409)

Fix all issues by checking with the CI, that:

* A builder key is present when an attestation is submitted
* The signature is valid at the time

Obviously CI does not check if a key is revoked or expired in the future. Also, CI will fail if "extraneous" keys are modified/added without attestation in the same pull. This should be rare and can be handled by manual review for now.

Implements and fixes https://github.com/bitcoin-core/guix.sigs/issues/133