### PR TITLE
ci: Rework CI log output (\n)

### DIFF
--- a/contrib/touched-files-check/src/main.rs
+++ b/contrib/touched-files-check/src/main.rs
@@ -104,8 +104,8 @@ fn main() {
         .expect("git error");
     assert!(git_diff.status.success());
     let touched_files = String::from_utf8(git_diff.stdout).expect("Invalid utf8");
-    let (atts, builder_keys) = check(&touched_files).expect("ci check failed");
-    check_attestations(atts, builder_keys).expect("ci check failed");
+    let (atts, builder_keys) = check(&touched_files).unwrap_or_else(|e| panic!("ci check failed:\n\n{e}\n\n"));
+    check_attestations(atts, builder_keys).unwrap_or_else(|e| panic!("ci check failed:\n\n{e}\n\n"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #549.

I'm not sure which is better. The current plan is A.

### Plan A

```
Touched file: A 23.1/theStack/all.SHA256SUMS
Touched file: A 23.1/theStack/all.SHA256SUMS.asc
Touched file: A 23.1/theStack/noncodesigned.SHA256SUMS
Touched file: A 23.1/theStack/noncodesigned.SHA256SUMS.asc
Touched file: A builder-keys/theStack.gpg
thread 'main' panicked at 'ci check failed: Builder key not found for attestation. Attestation: '23.1/theStack/noncodesigned.SHA256SUMS', Key: 'builder-keys/theStack.gpg', Error: 'No such file or directory (os error 2)'.
Help: Run 'gpg --export --armor theStack > builder-keys/theStack.gpg && git add builder-keys/theStack.gpg'', src/main.rs:108:65
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### Plan B

```
Touched file: A 23.1/theStack/all.SHA256SUMS
Touched file: A 23.1/theStack/all.SHA256SUMS.asc
Touched file: A 23.1/theStack/noncodesigned.SHA256SUMS
Touched file: A 23.1/theStack/noncodesigned.SHA256SUMS.asc
Touched file: A builder-keys/theStack.gpg
Builder key not found for attestation. Attestation: '23.1/theStack/noncodesigned.SHA256SUMS', Key: 'builder-keys/theStack.gpg', Error: 'No such file or directory (os error 2)'.
Help: Run 'gpg --export --armor theStack > builder-keys/theStack.gpg && git add builder-keys/theStack.gpg'
thread 'main' panicked at 'ci check failed', src/main.rs:110:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```