### PR TITLE
Signaling-only CI job to detect mismatching build artifact hashes early

### DIFF
--- a/.github/workflows/shasum-summary.yml
+++ b/.github/workflows/shasum-summary.yml
@@ -1,0 +1,38 @@
+name: comment a SHASUM summary for each changed release
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  comment-summary:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ github.event.pull_request.commits }} 
+      - name: show changed files
+        run: git diff --no-commit-id --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+      - name: run shasum-summary
+        run: python3 contrib/shasum-summary/main.py ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} > comment
+      - name: show comment
+        run: cat comment
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('node:fs');
+            fs.readFile('comment', 'utf8', (err, comment) => {
+              if (err) {
+                console.error(err);
+                return;
+              }
+              if (comment.length > 0) {
+                github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: "${{ github.event.pull_request.head.sha }}\n\n" + comment
+                });
+              }
+            });

--- a/contrib/shasum-summary/main.py
+++ b/contrib/shasum-summary/main.py
@@ -1,0 +1,136 @@
+import glob
+import string
+import argparse
+import subprocess
+
+USERNAME_ALPHABET = list(string.ascii_letters)
+SYMBOLS = ["◆", "▞", "▄", "▀", "▌", "▐", "▚"]
+SYMBOL_MATCH = "█"
+SYMBOL_MISSING = "X"
+
+
+def changed_files(diffrange):
+    changed_files = set()
+    p = subprocess.run(
+        ["git", "diff", "--no-commit-id", "--name-only", diffrange],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    git_changed_files = p.stdout.strip().split("\n")
+    for line in git_changed_files:
+        # filter out changed files where the path does not start with a number
+        # (as part of the release version) and signatures files (*.asc)
+        if (
+            not len(line) == 0
+            and line[0] in string.digits
+            and not line.endswith(".asc")
+        ):
+            path_parts = line.split("/")
+            if len(path_parts) == 3:
+                # <release>/<user>/<SHASUM file>
+                release, _, filename = path_parts
+                changed_files.add((release, filename))
+    return changed_files
+
+
+def read_files(changed_files):
+    data = dict()
+    for release, filename in changed_files:
+        if release not in data:
+            data[release] = {}
+        files = glob.glob(f"{release}/*/{filename}")
+        for file in files:
+            user = file.split("/")[1]
+            with open(file) as f:
+                if filename not in data[release]:
+                    data[release][filename] = {}
+                data[release][filename][user] = {}
+
+                for line in f.readlines():
+                    if len(line.strip()) == 0:
+                        continue
+
+                    hashsum, artifact = line.strip().split("  ")
+                    data[release][filename][user][artifact] = hashsum
+    return data
+
+
+def hash_to_symbol(hash, hashes):
+    # all hashes match
+    if len(hashes) == 1:
+        return SYMBOL_MATCH
+    # Sorting the hashes by occurrence count descending allows us to
+    # display the most common hash (if any) with the same symbol.
+    # If no hashes match, we essentially pick a random symbol.
+    sorted_hashes = dict(sorted(hashes.items(), reverse=True, key=lambda item: item[1]))
+    return SYMBOLS[list(sorted_hashes.keys()).index(hash) % len(SYMBOLS)]
+
+
+def print_summaries(data):
+    for release in sorted(data):
+        for filename in data[release]:
+            artifacts = dict()
+            for user in data[release][filename]:
+                for artifact in data[release][filename][user]:
+                    if artifact not in artifacts:
+                        artifacts[artifact] = dict()
+                    hashsum = data[release][filename][user][artifact]
+                    if hashsum not in artifacts[artifact]:
+                        artifacts[artifact][hashsum] = 0
+                    artifacts[artifact][hashsum] += 1
+
+            SHORT_ARTIFACT_REPLACE = f"bitcoin-{release}-"
+            artifact_max_length = max(
+                [
+                    len(artifact.replace(SHORT_ARTIFACT_REPLACE, ""))
+                    for artifact in artifacts
+                ]
+            )
+
+            text = f"`{filename}` summary for release `{release}`\n"
+            text += "```\n"
+            text += f"{'User (see mapping below)'.ljust(artifact_max_length, ' ')} {' '.join([USERNAME_ALPHABET[idx % len(USERNAME_ALPHABET)] for idx in range(len(data[release][filename]))]  )}\n"
+            for artifact in sorted(artifacts):
+                short_artifact = artifact.replace(SHORT_ARTIFACT_REPLACE, "")
+                symbols = " ".join(
+                    [
+                        hash_to_symbol(
+                            data[release][filename][user][artifact], artifacts[artifact]
+                        )
+                        if artifact in data[release][filename][user]
+                        else SYMBOL_MISSING
+                        for user in data[release][filename]
+                    ]
+                )
+                text += f"{short_artifact.ljust(artifact_max_length, ' ')} {symbols}\n"
+            text += "```\n\n"
+
+            text += "<details><summary>Details</summary>\n"
+            text += f"Symbols:\n\n"
+            text += f"- all hashes match: `{SYMBOL_MATCH}`\n"
+            text += f"- missing hash: `{SYMBOL_MISSING}`\n"
+            text += f"- hash mismatch: one of `{'`, `'.join(SYMBOLS)}`\n\n"
+            text += "Username mapping:\n"
+            for idx, user in enumerate(data[release][filename]):
+                text += f"- {USERNAME_ALPHABET[idx % len(USERNAME_ALPHABET)]}: {user}\n"
+            text += "\n</details>\n"
+            print(text)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Output a SHASUM summary to stdout")
+    parser.add_argument(
+        "diffrange",
+        type=str,
+        help="Only look at added or changed files in the diff-range",
+    )
+    args = parser.parse_args()
+
+    changed_shasum_files = changed_files(args.diffrange)
+    data = read_files(changed_shasum_files)
+    print_summaries(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/touched-files-check/src/main.rs
+++ b/contrib/touched-files-check/src/main.rs
@@ -57,7 +57,7 @@ fn check(touched_files: &str) -> Result<(Vec<&str>, HashSet<&str>), String> {
             (l.next().unwrap(), l.next().unwrap())
         };
         println!("Touched file: {status} {file}");
-        if ["README.md", ".cirrus.yml", "contrib/"]
+        if ["README.md", ".cirrus.yml", "contrib/", ".github/"]
             .iter()
             .any(|ignore| file.starts_with(ignore))
         {


### PR DESCRIPTION
To detect build non-determinism and mismatching artifact hashes early (https://github.com/bitcoin-core/guix.sigs/issues/1203), this introduces a CI job that comments a visual summary of the SHASUMs for each added/changed release. Before merging, it can be quickly visually verified that there are no mismatches. The CI job does **not** fail on mismatches - it only signals that there's a problem. It also does **not** check signature validity.

For example, when a `noncodesigned.SHA256SUMS` file for `24.2` is added, the CI job would comment on the PR:

----

`noncodesigned.SHA256SUMS` summary for release `24.2`
```
User (see mapping below)            a b c d e f g h i j k l m n o p q
aarch64-linux-gnu-debug.tar.gz      █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
aarch64-linux-gnu.tar.gz            █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
arm-linux-gnueabihf-debug.tar.gz    █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
arm-linux-gnueabihf.tar.gz          █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
arm64-apple-darwin-unsigned.dmg     █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
arm64-apple-darwin-unsigned.tar.gz  █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
arm64-apple-darwin.tar.gz           █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
powerpc64-linux-gnu-debug.tar.gz    █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
powerpc64-linux-gnu.tar.gz          █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
powerpc64le-linux-gnu-debug.tar.gz  █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
powerpc64le-linux-gnu.tar.gz        █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
riscv64-linux-gnu-debug.tar.gz      █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
riscv64-linux-gnu.tar.gz            █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
win64-debug.zip                     █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
win64-setup-unsigned.exe            █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
win64-unsigned.tar.gz               █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
win64.zip                           █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
x86_64-apple-darwin-unsigned.dmg    █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
x86_64-apple-darwin-unsigned.tar.gz █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
x86_64-apple-darwin.tar.gz          █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
x86_64-linux-gnu-debug.tar.gz       █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
x86_64-linux-gnu.tar.gz             █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
bitcoin-24.2.tar.gz                 █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █ █
```

<details><summary>Details</summary>
Symbols:
 - all hashes match: `█`
 - missing hash: `X`
 - hash mismatch: one of `░`, `▞`, `▄`, `▀`, `▌`, `▐`, `▚`

Username mapping:
- a: willyko
- b: jackielove4u
- c: hebasto
- d: kvaciral
- e: TheCharlatan
- f: 0xb10c
- g: laanwj
- h: svanstaa
- i: glozow
- j: Emzy
- k: achow101
- l: Sjors
- m: fanquake
- n: guggero
- o: theStack
- p: benthecarman
- q: josibake

</details>

----

Here, all rows having only `█`'s means that there are **no** hash mismatches. Other examples can be found here: https://github.com/0xB10C/guix.sigs/pull/2 


closes #1203


