### PR TITLE
ci: fix fetch-depth and split workflows

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,0 +1,39 @@
+name: Comment on PR
+
+on:
+  workflow_run:
+    workflows: ["SHASUM summary"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: shasum-comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            let issue_number = Number(fs.readFileSync('./issue-number', 'utf8').trim());
+            let comment = fs.readFileSync('./comment', 'utf8').trim();
+
+            if (comment.length > 0) {
+              github.rest.issues.createComment({
+                issue_number: issue_number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: "${{ github.event.pull_request.head.sha }}\n\n" + comment
+              });
+            }

--- a/.github/workflows/shasum-summary.yml
+++ b/.github/workflows/shasum-summary.yml
@@ -1,4 +1,4 @@
-name: comment a SHASUM summary for each changed release
+name: SHASUM summary
 
 on:
   pull_request:
@@ -12,27 +12,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: show changed files
-        run: git diff --no-commit-id --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+        run: |
+          git diff --no-commit-id --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       - name: run shasum-summary
         run: python3 contrib/shasum-summary/main.py ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} > comment
       - name: show comment
         run: cat comment
-      - uses: actions/github-script@v7
+      - name: Store issue number
+        run: echo "${{ github.event.number }}" > issue-number
+      - name: Verify issue number file
+        run: cat issue-number
+      - uses: actions/upload-artifact@v4
         with:
-          script: |
-            const fs = require('node:fs');
-            fs.readFile('comment', 'utf8', (err, comment) => {
-              if (err) {
-                console.error(err);
-                return;
-              }
-              if (comment.length > 0) {
-                github.rest.issues.createComment({
-                  issue_number: context.issue.number,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  body: "${{ github.event.pull_request.head.sha }}\n\n" + comment
-                });
-              }
-            });
+          name: shasum-comment
+          path: |
+            comment
+            issue-number

--- a/.github/workflows/shasum-summary.yml
+++ b/.github/workflows/shasum-summary.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ github.event.pull_request.commits }} 
+          fetch-depth: 0
       - name: show changed files
         run: git diff --no-commit-id --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       - name: run shasum-summary


### PR DESCRIPTION
This fixes the fetch-depth issue (https://github.com/bitcoin-core/guix.sigs/pull/1207#issuecomment-2161352980) and splits the CI into two workflows to work around the missing comment permissions from external forks:

 1. For PRs against `main`, generate the SHASUM summary comment and upload it as a "build-artifact" (GitHub forbids the usage of `GITHUB_TOKEN` to e.g. comment on the PR from external forks)
 2. When 1. succeeds, run a workflow that downloads the "build-artifact" and comments on the PR

For more context, see the discussion starting here: https://github.com/bitcoin-core/guix.sigs/pull/1207#issuecomment-2142808765

