### PR TITLE
ci: Checkout pr merge commit instead of head

### DIFF
--- a/.github/workflows/shasum-summary.yml
+++ b/.github/workflows/shasum-summary.yml
@@ -12,12 +12,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: show changed files
         run: |
-          git diff --no-commit-id --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+          git diff --no-commit-id --name-only ${{ github.event.pull_request.base.sha }}..HEAD
       - name: run shasum-summary
-        run: python3 contrib/shasum-summary/main.py ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} > comment
+        run: python3 contrib/shasum-summary/main.py ${{ github.event.pull_request.base.sha }}..HEAD > comment
       - name: show comment
         run: cat comment
       - name: Store issue number


### PR DESCRIPTION
Change the shasum summary CI to use the pr merge commit (github's default checkout) rather than the head of the pr. This resolves an issue where changes to the base branch would appear in the `git diff`. This also ensures that the task is run on the most recent version of the base branch so that more comparisons can be done.