### PR TITLE
Grant comment workflow permissions

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   comment:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.event == 'pull_request' &&


### PR DESCRIPTION
Only require the minimal permissions to write a comment on a pull-request.

Allows repo-level workflow permissions to be set to read-only:

> Read repository contents and packages permissions
>   Workflows have read permissions in the repository for the contents and packages scopes only.